### PR TITLE
Update OkHttp to 5.1.0 and update Kotlin to 2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+.kotlin/errors/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 .cxx
 local.properties
 
-.kotlin/errors/
+.kotlin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,14 @@
 [versions]
 agp = "8.5.1"
-kotlin = "1.9.24"
+kotlin = "2.2.0"
+kotlinx-immutable = "0.4.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 jsonunit = "3.4.1"
 appcompat = "1.7.0"
 material = "1.12.0"
 moshi = "1.15.1"
-okhttp = "4.12.0"
+okhttp = "5.1.0"
 assertj = "3.26.3"
 lifecycleProcess = "2.8.4"
 kotlinxCoroutinesTest = "1.8.1"
@@ -23,6 +24,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+kotlinx-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-immutable" }
 moshi-kotlin = { group = "com.squareup.moshi", name="moshi-kotlin", version.ref = "moshi" }
 moshi-adapters = { group = "com.squareup.moshi", name="moshi-adapters", version.ref = "moshi" }
 robolectric-test = { group = "org.robolectric", name = "robolectric", version = "4.13" }
@@ -44,3 +46,4 @@ androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtim
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.1"
+agp = "8.12.2"
 kotlin = "2.2.0"
 kotlinx-immutable = "0.4.0"
 coreKtx = "1.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unleashandroidsdk/build.gradle.kts
+++ b/unleashandroidsdk/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.moshi.kotlin)
     implementation(libs.moshi.adapters)
+    implementation(libs.kotlinx.immutable)
     api(libs.okhttp)
 
     testImplementation(libs.junit)

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
@@ -31,6 +31,7 @@ import io.getunleash.android.metrics.NoOpMetrics
 import io.getunleash.android.polling.UnleashFetcher
 import io.getunleash.android.tasks.DataJob
 import io.getunleash.android.tasks.LifecycleAwareTaskManager
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -47,7 +48,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import okhttp3.internal.toImmutableList
 import java.io.File
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean


### PR DESCRIPTION
## About the changes
This PR makes the necessary changes to update the OkHttp dependency to 5.x.  OkHttp requires Kotlin 2.0 minimum, so I had to update the Kotlin version as well, and the compose-compiler plugin is due to a change required by Kotlin 2.x.  The compose compiler plugin is not applied in the SDK module.

The failure when updating OkHttp was happening due to the usage of an internal toImmutableList function in OkHttp.  Assuming you had a good reason to use an `ImmutableList` and not a standard readonly `List`, I added the kotlinx Immutable Collections dependency to replace the internal OkHttp usage.

<!-- Does it close an issue? Multiple? -->
Closes #98 

## Discussion points
I did not include any versioning changes here because I am not sure how that process works for you guys internally.  Updating the kotlin version could be cause for a major version bump, but moving to Kotlin 2.x is important in modern android development anyway. 
