### PR TITLE
fix: network available listener

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/http/NetworkStatusHelper.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/http/NetworkStatusHelper.kt
@@ -38,10 +38,6 @@ class NetworkStatusHelper(private val context: Context) {
                 listener.onAvailable()
             }
 
-            override fun onUnavailable() {
-                listener.onLost()
-            }
-
             override fun onLost(network: Network) {
                 availableNetworks -= network
                 if (availableNetworks.isEmpty()) {

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/http/NetworkStatusHelper.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/http/NetworkStatusHelper.kt
@@ -20,6 +20,8 @@ class NetworkStatusHelper(val context: Context) {
 
     internal val networkCallbacks = mutableListOf<ConnectivityManager.NetworkCallback>()
 
+    private val availableNetworks = mutableSetOf<Network>()
+
     fun registerNetworkListener(listener: NetworkListener) {
         val connectivityManager = getConnectivityManager() ?: return
         val requestBuilder = NetworkRequest.Builder()
@@ -32,6 +34,7 @@ class NetworkStatusHelper(val context: Context) {
         // wrap the listener in a NetworkCallback so the listener doesn't have to know about Android specifics
         val networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
+                availableNetworks += network
                 listener.onAvailable()
             }
 
@@ -40,7 +43,10 @@ class NetworkStatusHelper(val context: Context) {
             }
 
             override fun onLost(network: Network) {
-                listener.onLost()
+                availableNetworks -= network
+                if (availableNetworks.isEmpty()) {
+                    listener.onLost()
+                }
             }
         }
 

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/http/NetworkStatusHelper.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/http/NetworkStatusHelper.kt
@@ -13,7 +13,7 @@ interface NetworkListener {
     fun onLost()
 }
 
-class NetworkStatusHelper(val context: Context) {
+class NetworkStatusHelper(private val context: Context) {
     companion object {
         private const val TAG = "NetworkState"
     }
@@ -54,7 +54,7 @@ class NetworkStatusHelper(val context: Context) {
         networkCallbacks += networkCallback
     }
 
-    fun close () {
+    fun close() {
         val connectivityManager = getConnectivityManager() ?: return
         networkCallbacks.forEach {
             connectivityManager.unregisterNetworkCallback(it)

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/http/NetworkStatusHelperTest.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/http/NetworkStatusHelperTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -108,6 +109,7 @@ class NetworkStatusHelperTest : BaseTest() {
     @Config(sdk = [23])
     fun `can register a network listener with API level above 23`() {
         val network = mock(Network::class.java)
+        val network2 = mock(Network::class.java)
         val context = contextWithNetwork(
             network,
             NetworkCapabilities.NET_CAPABILITY_VALIDATED,
@@ -121,10 +123,12 @@ class NetworkStatusHelperTest : BaseTest() {
 
         networkStatusHelper.networkCallbacks[0].onAvailable(network)
         verify(listener).onAvailable()
+        networkStatusHelper.networkCallbacks[0].onAvailable(network2)
+        verify(listener, times(2)).onAvailable()
         networkStatusHelper.networkCallbacks[0].onLost(network)
+        verify(listener, never()).onLost()
+        networkStatusHelper.networkCallbacks[0].onLost(network2)
         verify(listener).onLost()
-        networkStatusHelper.networkCallbacks[0].onUnavailable()
-        verify(listener, times(2)).onLost()
     }
 
     private fun contextWithNetwork(network: Network?, vararg capabilities: Int): Context {


### PR DESCRIPTION
## About the changes

In the current version, the latest received event triggers the `onAvailable` and `onLost` methods, which start or stop jobs. The problem arises when many Android devices (for example, a Google Pixel running Android 15 - API 35) can handle multiple available networks simultaneously. In such cases, any single network loss will cause the jobs (polling and metrics) to stop, even though the device still has an active internet connection.

With this fix, `onLost` will only be called when all available networks are lost.

## Discussion points

You should consider if you want to call `onAvailable` listener's code on each event received or only when is the first available network. I left this untouched mantaining the original behaviour but I think it should only be called the on the first one.
