### PR TITLE
fix: should be ready without a listener

### DIFF
--- a/app/src/main/java/io/getunleash/unleashandroid/TestApplication.kt
+++ b/app/src/main/java/io/getunleash/unleashandroid/TestApplication.kt
@@ -10,7 +10,7 @@ import io.getunleash.android.events.UnleashReadyListener
 import io.getunleash.android.events.UnleashStateListener
 import java.util.Date
 
-const val initialFlagValue = "flag-1"
+const val initialFlagValue = "unleash-android-test"
 const val initialUserId = "123"
 object UnleashStats {
     var readySince: Date? = null


### PR DESCRIPTION
When listeners are not present, the sdk is not switching to ready.
Also, it's changing to ready after changing the context, and it should be ready only when features have been loaded