### PR TITLE
fix: upstream data should be preferred over local backup

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/backup/LocalBackup.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/backup/LocalBackup.kt
@@ -21,7 +21,7 @@ data class BackupState(val contextId: String, val toggles: Map<String, Toggle>)
  * Because it only keeps the last state, it also saves the context id, and uses it to verify the context
  * is the same when loading the state from disc.
  */
-class LocalBackup(
+open class LocalBackup(
     private val localDir: File,
     private var lastContext: UnleashContext? = null
 ) {
@@ -46,7 +46,7 @@ class LocalBackup(
         }
     }
 
-    private fun writeToDisc(state: UnleashState) {
+    open fun writeToDisc(state: UnleashState) {
         try {
             // write only the last state
             val contextBackup = File(localDir.absolutePath, STATE_BACKUP_FILE)
@@ -64,7 +64,7 @@ class LocalBackup(
         }
     }
 
-    fun loadFromDisc(context: UnleashContext): UnleashState? {
+    open fun loadFromDisc(context: UnleashContext): UnleashState? {
         val stateBackup = File(localDir.absolutePath, STATE_BACKUP_FILE)
         try {
             if (stateBackup.exists()) {

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/polling/UnleashFetcher.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/polling/UnleashFetcher.kt
@@ -11,6 +11,7 @@ import io.getunleash.android.errors.ServerException
 import io.getunleash.android.events.HeartbeatEvent
 import io.getunleash.android.http.Throttler
 import io.getunleash.android.unleashScope
+import kotlinx.coroutines.CoroutineScope
 import java.io.Closeable
 import java.io.IOException
 import java.util.concurrent.TimeUnit

--- a/unleashandroidsdk/src/test/java/io/getunleash/android/backup/TestLocalBackup.kt
+++ b/unleashandroidsdk/src/test/java/io/getunleash/android/backup/TestLocalBackup.kt
@@ -1,0 +1,34 @@
+package io.getunleash.android.backup
+
+import io.getunleash.android.data.UnleashContext
+import io.getunleash.android.data.UnleashState
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Test helper that blocks loadFromDisc until the provided latch is counted down.
+ */
+open class TestLocalBackup(
+    localDir: File,
+    private val startLatch: CountDownLatch,
+    private val timeoutSeconds: Long = 5,
+    var writeCalls: Int = 0
+) : LocalBackup(localDir) {
+
+    override fun loadFromDisc(context: UnleashContext): UnleashState? {
+        // wait until the test releases the latch to simulate a slow disk load
+        try {
+            startLatch.await(timeoutSeconds, TimeUnit.SECONDS)
+        } catch (e: InterruptedException) {
+            // ignore
+        }
+        return super.loadFromDisc(context)
+    }
+
+    override fun writeToDisc(state: UnleashState) {
+        super.writeToDisc(state)
+        writeCalls++
+    }
+}
+


### PR DESCRIPTION
## About the changes
Under some conditions, the backup behavior could override the upstream data as "current data". This could lead to invalid evaluations until upstream configuration is modified, causing the fetcher to fetch latest data.

This should supersede the fix proposed in https://github.com/Unleash/unleash-android-sdk/pull/111
