### PR TITLE
fix: deprecate default parameters

### DIFF
--- a/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
@@ -227,6 +227,21 @@ class DefaultUnleash(
         }
     }
 
+    override fun isEnabled(toggleName: String): Boolean {
+        val toggle = cache.get(toggleName)
+        val enabled = toggle?.enabled ?: false
+        val impressionData = unleashConfig.forceImpressionData || toggle?.impressionData ?: false
+        if (impressionData) {
+            emit(ImpressionEvent(toggleName, enabled, unleashContextState.value))
+        }
+        metrics.count(toggleName, enabled)
+        return enabled
+    }
+
+    @Deprecated(
+        "Use isEnabled(toggleName: String) instead",
+        replaceWith = ReplaceWith("isEnabled(toggleName)")
+    )
     override fun isEnabled(toggleName: String, defaultValue: Boolean): Boolean {
         val toggle = cache.get(toggleName)
         val enabled = toggle?.enabled ?: defaultValue
@@ -238,6 +253,22 @@ class DefaultUnleash(
         return enabled
     }
 
+    override fun getVariant(toggleName: String): Variant {
+        val toggle = cache.get(toggleName)
+        val enabled = isEnabled(toggleName)
+        val variant = if (enabled) (toggle?.variant ?: disabledVariant) else disabledVariant
+        val impressionData = toggle?.impressionData ?: unleashConfig.forceImpressionData
+        if (impressionData) {
+            emit(ImpressionEvent(toggleName, enabled, unleashContextState.value, variant.name))
+        }
+        metrics.countVariant(toggleName, variant)
+        return variant
+    }
+
+    @Deprecated(
+        "Use getVariant(toggleName: String) instead",
+        replaceWith = ReplaceWith("getVariant(toggleName)")
+    )
     override fun getVariant(toggleName: String, defaultValue: Variant): Variant {
         val toggle = cache.get(toggleName)
         val enabled = isEnabled(toggleName)

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/DefaultUnleash.kt
@@ -239,7 +239,7 @@ class DefaultUnleash(
     }
 
     @Deprecated(
-        "Use isEnabled(toggleName: String) instead",
+        "Use isEnabled(toggleName: String) instead. See https://github.com/Unleash/unleash-android-sdk/issues/141",
         replaceWith = ReplaceWith("isEnabled(toggleName)")
     )
     override fun isEnabled(toggleName: String, defaultValue: Boolean): Boolean {
@@ -266,7 +266,7 @@ class DefaultUnleash(
     }
 
     @Deprecated(
-        "Use getVariant(toggleName: String) instead",
+        "Use getVariant(toggleName: String) instead. See https://github.com/Unleash/unleash-android-sdk/issues/141",
         replaceWith = ReplaceWith("getVariant(toggleName)")
     )
     override fun getVariant(toggleName: String, defaultValue: Variant): Variant {

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/Unleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/Unleash.kt
@@ -15,7 +15,7 @@ interface Unleash: Closeable {
      * @deprecated use [isEnabled(toggleName: String)] instead. Using default values can lead to unexpected behavior.
      * @see https://github.com/Unleash/unleash-android-sdk/issues/141
      */
-    @Deprecated("Use isEnabled(toggleName: String) instead", ReplaceWith("isEnabled(toggleName)"))
+    @Deprecated("Use isEnabled(toggleName: String) instead. See https://github.com/Unleash/unleash-android-sdk/issues/141", ReplaceWith("isEnabled(toggleName)"))
     fun isEnabled(toggleName: String, defaultValue: Boolean): Boolean
 
     /**
@@ -28,7 +28,7 @@ interface Unleash: Closeable {
      * @deprecated use [getVariant(toggleName: String)] instead. Using default values can lead to unexpected behavior.
      * @see https://github.com/Unleash/unleash-android-sdk/issues/141
      */
-    @Deprecated("Use getVariant(toggleName: String) instead", ReplaceWith("getVariant(toggleName)"))
+    @Deprecated("Use getVariant(toggleName: String) instead. See https://github.com/Unleash/unleash-android-sdk/issues/141", ReplaceWith("getVariant(toggleName)"))
     fun getVariant(toggleName: String, defaultValue: Variant = disabledVariant): Variant
 
     /**

--- a/unleashandroidsdk/src/main/java/io/getunleash/android/Unleash.kt
+++ b/unleashandroidsdk/src/main/java/io/getunleash/android/Unleash.kt
@@ -12,13 +12,29 @@ val disabledVariant = Variant("disabled")
 interface Unleash: Closeable {
     /**
      * Check if a toggle is enabled or disabled
+     * @deprecated use [isEnabled(toggleName: String)] instead. Using default values can lead to unexpected behavior.
+     * @see https://github.com/Unleash/unleash-android-sdk/issues/141
      */
-    fun isEnabled(toggleName: String, defaultValue: Boolean = false): Boolean
+    @Deprecated("Use isEnabled(toggleName: String) instead", ReplaceWith("isEnabled(toggleName)"))
+    fun isEnabled(toggleName: String, defaultValue: Boolean): Boolean
+
+    /**
+     * Check if a toggle is enabled or disabled
+     */
+    fun isEnabled(toggleName: String): Boolean
+
+    /**
+     * Get the variant for a toggle
+     * @deprecated use [getVariant(toggleName: String)] instead. Using default values can lead to unexpected behavior.
+     * @see https://github.com/Unleash/unleash-android-sdk/issues/141
+     */
+    @Deprecated("Use getVariant(toggleName: String) instead", ReplaceWith("getVariant(toggleName)"))
+    fun getVariant(toggleName: String, defaultValue: Variant = disabledVariant): Variant
 
     /**
      * Get the variant for a toggle
      */
-    fun getVariant(toggleName: String, defaultValue: Variant = disabledVariant): Variant
+    fun getVariant(toggleName: String): Variant
 
     /**
      * Set context and trigger a fetch of the latest toggles immediately and block until the fetch is complete or failed.


### PR DESCRIPTION
## About the changes
As explained in issue #141, frontend SDKs should not provide a default value, as it may lead to incorrect behavior. 

The correct way of sending the expected initial state for features is through the bootstrap mechanism documented here: https://github.com/Unleash/unleash-android-sdk/?tab=readme-ov-file#step-4-option-2-provide-an-initial-state
 
A deprecation notice will instruct users to migrate to the method without a default value and link to the issue for more details.